### PR TITLE
add fediverse link verification and author attribution tags

### DIFF
--- a/themes/foulab-2018/layouts/_default/baseof.html
+++ b/themes/foulab-2018/layouts/_default/baseof.html
@@ -14,6 +14,9 @@
     <meta property="og:image:width" content="1124" />
     <meta property="og:image:height" content="1126" />
 
+    <meta name="fediverse:creator" content="@foulab@chaos.social">
+    <link rel="me" href="https://chaos.social/@foulab">
+
     <script type="text/javascript" >
       window.baseRoot = {{ .Site.BaseURL | safeHTML }};
     </script>


### PR DESCRIPTION
the `fediverse:creator` meta tag allows link cards for foulab.org to include a rich link to our fediverse profile. the `rel=me` link tag makes the link to foulab.org on the profile "verified".

see also:
- https://docs.joinmastodon.org/user/profile/#verification
- https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/